### PR TITLE
max number of scaffs to plot

### DIFF
--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -11,6 +11,7 @@ my $rawKaryotype  = "";
 my $scaffoldFiles = "";
 my $scafftigsBED  = "";
 my $agpFile       = "";
+my $maxCount      = -1;
 my $numScaff      = 90;
 my $rawConf       = "rawConf.conf";
 my $prefix        = "circos";
@@ -18,6 +19,7 @@ my $result        = GetOptions(
 	'k=s' => \$rawKaryotype,
 	's=s' => \$scaffoldFiles,
 	'n=i' => \$numScaff,
+	'm=i' => \$maxCount
 	'b=s' => \$scafftigsBED,
 	'a=s' => \$agpFile,
 	'r=s' => \$rawConf,
@@ -115,6 +117,10 @@ sub outputKaryotype {
 	foreach my $scaffoldID ( reverse @lengthOrder ) {
 
 		if ( ( $genomeSize * $numScaff ) <= $scaffoldSum ) {
+			last;
+		}
+		
+		if ( $count == $maxCount ) {
 			last;
 		}
 

--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -19,7 +19,7 @@ my $result        = GetOptions(
 	'k=s' => \$rawKaryotype,
 	's=s' => \$scaffoldFiles,
 	'n=i' => \$numScaff,
-	'm=i' => \$maxCount
+	'm=i' => \$maxCount,
 	'b=s' => \$scafftigsBED,
 	'a=s' => \$agpFile,
 	'r=s' => \$rawConf,

--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -120,7 +120,7 @@ sub outputKaryotype {
 			last;
 		}
 		
-		if ( $count == $maxCount ) {
+		if ( $count == $maxCount + 1 ) {
 			last;
 		}
 

--- a/jupiter
+++ b/jupiter
@@ -12,6 +12,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 #------------------------------------------------------------
 
 ng=75
+maxScaff=-1
 maxGap=100000
 minBundleSize=50000
 m=100000
@@ -78,7 +79,7 @@ endif
 	grep -v XA $< | grep -v '^@' | awk '{if($$5 > 50 || $$5 == "" ) print}' | perl $(ROOT_DIR)/bin/samToBed.pl > $@
 
 %.conf %.karyotype %.rv.links %.fw.links %.seqOrder.txt: %.agp %-agp.bed %_reference.karyotype %_scaffolds.fa.fai
-	perl $(ROOT_DIR)/bin/generateConf.pl -n $(ng) -r $(ROOT_DIR)/config/rawConf.conf -p $* -s $*_scaffolds.fa.fai -b $*-agp.bed -a $*.agp -k $*_reference.karyotype
+	perl $(ROOT_DIR)/bin/generateConf.pl -n $(ng) -m $(maxScaff) -r $(ROOT_DIR)/config/rawConf.conf -p $* -s $*_scaffolds.fa.fai -b $*-agp.bed -a $*.agp -k $*_reference.karyotype
 
 $(name)_reference.karyotype: $(name)_reference.fa
 	perl $(ROOT_DIR)/bin/generateKaryotype.pl -g $(g) -i $(i) -m $(m) $(name)_reference.fa > $@


### PR DESCRIPTION
With this minor change, the user can set the maximum number of scaffolds to be plotted.

May be used with a relatively high ng value to achieve an exact number of scaffolds plotted. This way sparsity accounts for (lower) quality, and makes comparison of two plots easier.