### PR TITLE
output genome coverage

### DIFF
--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -27,6 +27,7 @@ my $result        = GetOptions(
 );
 
 my $outputkaryotype = $prefix . ".karyotype";
+my $percentCoverage = 0;
 
 $numScaff = $numScaff / 100;
 
@@ -137,7 +138,10 @@ sub outputKaryotype {
 		$count++;
 	}
 	print STDERR "Selecting " . $count . " scaffolds to render\n";
-	print STDERR "By " . $count . " scaffolds, genome is covered " . $scaffoldSum . " bases of " . $genomeSize . " bases in total.\n";
+	if ( $maxCount > 0 ) {
+		$percentCoverage = ( 100 * $scaffoldSum ) / $genomeSize;
+		print STDERR "Selected scaffolds cover genome by " . $percentCoverage . " percent.\n";
+	}
 
 	#print out spacing information:
 	my $defaultSpacing = 0.002;

--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -140,7 +140,7 @@ sub outputKaryotype {
 	print STDERR "Selecting " . $count . " scaffolds to render\n";
 	if ( $maxCount > 0 ) {
 		$percentCoverage = ( 100 * $scaffoldSum ) / $genomeSize;
-		print STDERR "Selected scaffolds cover genome by " . $percentCoverage . " percent.\n";
+		print STDERR "Selected scaffolds cover genome by " . $percentCoverage . " percent\n";
 	}
 
 	#print out spacing information:

--- a/bin/generateConf.pl
+++ b/bin/generateConf.pl
@@ -137,6 +137,7 @@ sub outputKaryotype {
 		$count++;
 	}
 	print STDERR "Selecting " . $count . " scaffolds to render\n";
+	print STDERR "By " . $count . " scaffolds, genome is covered " . $scaffoldSum . " bases of " . $genomeSize . " bases in total.\n";
 
 	#print out spacing information:
 	my $defaultSpacing = 0.002;


### PR DESCRIPTION
A very minor addition: when users set a maxScaff value, the coverage is variable based on overall length of those `maxScaff` scaffolds. This makes the code to output the resulting genome coverage.